### PR TITLE
Added Swedish language

### DIFF
--- a/translations/sv_SE.ts
+++ b/translations/sv_SE.ts
@@ -1,0 +1,1008 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/mainwindow.ui" line="14"/>
+        <source>Media Downloader</source>
+        <translation type="Media Downloader"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="31"/>
+        <source>Basic Downloader</source>
+        <translation type="Enkel nerladdare"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="53"/>
+        <location filename="../src/mainwindow.ui" line="480"/>
+        <location filename="../src/mainwindow.ui" line="592"/>
+        <location filename="../src/mainwindow.ui" line="773"/>
+        <location filename="../src/mainwindow.ui" line="1811"/>
+        <source>Cancel</source>
+        <translation type="Avbryt"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="66"/>
+        <location filename="../src/mainwindow.ui" line="760"/>
+        <source>Get List</source>
+        <translation type="Hämta lista"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="79"/>
+        <location filename="../src/mainwindow.ui" line="364"/>
+        <source>Enter URL:</source>
+        <translation type="Ange webbadress"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="98"/>
+        <location filename="../src/mainwindow.ui" line="306"/>
+        <source>Enter Options:</source>
+        <translation type="Ange alternativ:"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="117"/>
+        <location filename="../src/mainwindow.ui" line="454"/>
+        <location filename="../src/mainwindow.ui" line="643"/>
+        <source>Download</source>
+        <translation type="Ladda ner"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="150"/>
+        <location filename="../src/mainwindow.ui" line="467"/>
+        <location filename="../src/mainwindow.ui" line="611"/>
+        <location filename="../src/mainwindow.ui" line="1501"/>
+        <location filename="../src/mainwindow.ui" line="1551"/>
+        <location filename="../src/mainwindow.ui" line="1762"/>
+        <source>Options</source>
+        <translation type="Alternativ"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="163"/>
+        <location filename="../src/mainwindow.ui" line="506"/>
+        <location filename="../src/mainwindow.ui" line="695"/>
+        <location filename="../src/mainwindow.ui" line="1095"/>
+        <location filename="../src/mainwindow.ui" line="1827"/>
+        <location filename="../src/mainwindow.cpp" line="73"/>
+        <source>Quit</source>
+        <translation type="Avsluta"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="202"/>
+        <source>Format Code</source>
+        <translation type="Formatkod"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="207"/>
+        <source>Extension</source>
+        <translation type="Tillägg"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="212"/>
+        <source>Resolution</source>
+        <translation type="Upplösning"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="217"/>
+        <source>Note</source>
+        <translation type="Observera"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="231"/>
+        <location filename="../src/mainwindow.ui" line="287"/>
+        <location filename="../src/mainwindow.ui" line="799"/>
+        <source>Engine Name:</source>
+        <translation type="Motornamn:"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="250"/>
+        <location filename="../src/mainwindow.ui" line="818"/>
+        <source>Paste Clipboard Content</source>
+        <translation type="Klistra in urklippsinnehåll"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="266"/>
+        <location filename="../src/mainwindow.ui" line="438"/>
+        <location filename="../src/mainwindow.ui" line="834"/>
+        <location filename="../src/mainwindow.ui" line="850"/>
+        <source>Recently Used</source>
+        <translation type="Nyligen använd"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="275"/>
+        <source>Batch Downloader</source>
+        <translation type="Flernerladdare"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="335"/>
+        <location filename="../src/mainwindow.ui" line="741"/>
+        <source>Thumbnail</source>
+        <translation type="Miniatyr"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="340"/>
+        <location filename="../src/mainwindow.ui" line="746"/>
+        <source>Url To Download</source>
+        <translation type="Webbadress att ladda ner"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="383"/>
+        <source>Paste Clipboard Url</source>
+        <translation type="Klistra in urklippswebbadress"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="399"/>
+        <source>Monitor Clipboard For Url</source>
+        <translation type="Övervaka urklippet efter webbadresser"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="493"/>
+        <source>Add Url To List</source>
+        <translation type="Lägg till webbadressen i listan"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="579"/>
+        <source>Set</source>
+        <translation type="Ställ in"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="599"/>
+        <source>Playlist Downloader</source>
+        <translation type="Spellistnerladdare"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="666"/>
+        <source>Download Options:</source>
+        <translation type="Nerladdningsalternativ"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="708"/>
+        <source>Enter Playlist URL:</source>
+        <translation type="Ange spellistwebbadress:"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1045"/>
+        <source>Library</source>
+        <translation type="Bibliotek"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1076"/>
+        <source>Type</source>
+        <translation type="Typ"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1108"/>
+        <source>Up</source>
+        <translation type="Upp"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1121"/>
+        <source>Refresh</source>
+        <translation type="Uppdatera"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1134"/>
+        <source>Open Folder</source>
+        <translation type="Öppna mapp"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1147"/>
+        <source>Home</source>
+        <translation type="Hem"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1153"/>
+        <source>Configure</source>
+        <translation type="Konfigurera"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1169"/>
+        <source>General Options</source>
+        <translation type="Allmänna alternativ"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1275"/>
+        <source>Update Engine</source>
+        <translation type="Uppdatera motor"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1333"/>
+        <source>Show Thumbnails</source>
+        <translation type="Visa miniatyrer"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1375"/>
+        <source>Use System Executables If Available</source>
+        <translation type="Använd systemkörbara filer om tillgängliga"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1398"/>
+        <source>Dark Theme(Need A Restart)</source>
+        <translation type="Mörkt tema (kräver omstart)"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1430"/>
+        <source>Show Tray Icon</source>
+        <translation type="Visa ikon i meddelandefältet"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1443"/>
+        <source>Auto Save List Of Not Downloaded Media</source>
+        <translation type="Spara automatiskt en lista över icke nerladdad media"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1461"/>
+        <source>Reset Option To Its Default</source>
+        <translation type="Återställ till standardalternativ"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1464"/>
+        <location filename="../src/mainwindow.ui" line="1643"/>
+        <source>Set Defaults</source>
+        <translation type="Ställ in standard"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1301"/>
+        <source>Scale Factor(Need A Restart)</source>
+        <translation type="Skalfaktor (kräver omstart)"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1356"/>
+        <source>Maximum Cuncurrent Downloads</source>
+        <translation type="Maximalt antal samtidiga nerladdningar"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1449"/>
+        <source>Preset Options</source>
+        <translation type="Förinställda alternativ"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1256"/>
+        <source>Download Path</source>
+        <translation type="Nerladdningssökväg"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1204"/>
+        <source>Select Language</source>
+        <translation type="Välj språk"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1223"/>
+        <source>Show Version Info When Starting</source>
+        <translation type="Visa versionsinformation vid start"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1320"/>
+        <source>Add a Plugin</source>
+        <translation type="Lägg till en plugin"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1288"/>
+        <source>Remove A Plugin</source>
+        <translation type="Ta bort en plugin"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1840"/>
+        <source>Save</source>
+        <translation type="Spara"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1576"/>
+        <source>Engine&apos;s Default Options</source>
+        <translation type="Motorernas standardalternativ"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="624"/>
+        <location filename="../src/mainwindow.ui" line="1032"/>
+        <source>Get List Options:</source>
+        <translation type="Hämta listalternativ"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="866"/>
+        <source>Subscriptions</source>
+        <translation type="Prenumerationer"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="894"/>
+        <location filename="../src/mainwindow.ui" line="952"/>
+        <location filename="../src/mainwindow.ui" line="1496"/>
+        <location filename="../src/mainwindow.ui" line="1535"/>
+        <source>Ui Name</source>
+        <translation type="Gränssnittsnamn"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="974"/>
+        <location filename="../src/mainwindow.ui" line="1570"/>
+        <location filename="../src/mainwindow.ui" line="1798"/>
+        <source>Add</source>
+        <translation type="Lägg till"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="987"/>
+        <location filename="../src/mainwindow.ui" line="1696"/>
+        <source>Url</source>
+        <translation type="Webbadress"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1009"/>
+        <source>Done</source>
+        <translation type="Klar"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1598"/>
+        <source>Engine&apos;s Name</source>
+        <translation type="Motorernas namn"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1617"/>
+        <source>Default Download Options</source>
+        <translation type="Standardalternativ för nerladdning"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1656"/>
+        <source>Path To Cookie FIle</source>
+        <translation type="Sökväg till cookie-fil"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1701"/>
+        <source>Download Options</source>
+        <translation type="Nerladdningsalternativ"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1715"/>
+        <source>Set What Url Should Be Managed By What Engine</source>
+        <translation type="Ställ in vilken webbadress som ska hanteras av vilken motor"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1746"/>
+        <source>Url Filter</source>
+        <translation type="Webbadressfilter"></translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1846"/>
+        <source>About</source>
+        <translation type="Om"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/utility.cpp" line="395"/>
+        <source>Best-audiovideo</source>
+        <translation type="Bästa-ljudvideo"></translation>
+    </message>
+    <message>
+        <location filename="../src/utility.cpp" line="396"/>
+        <source>Best-audio</source>
+        <translation type="Bästa-ljud"></translation>
+    </message>
+    <message>
+        <location filename="../src/utility.cpp" line="397"/>
+        <source>Default</source>
+        <translation type="Standard"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="123"/>
+        <location filename="../src/utility.cpp" line="706"/>
+        <location filename="../src/utility.cpp" line="725"/>
+        <source>Save List To File</source>
+        <translation type="Spara lista till fil"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="756"/>
+        <source>Author</source>
+        <translation type="Upphovsman"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="766"/>
+        <source>Date</source>
+        <translation type="Datum"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="784"/>
+        <source>Replies to</source>
+        <translation type="Svar till"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="791"/>
+        <source>Text</source>
+        <translation type="Text"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="1008"/>
+        <source>Save Subtitle To File</source>
+        <translation type="Spara undertext till fil"></translation>
+    </message>
+    <message>
+        <location filename="../src/utility.h" line="158"/>
+        <source>Engine Name:</source>
+        <translation type="Motornamn:"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="1266"/>
+        <source>Get List From File</source>
+        <translation type="Hämta lista från fil"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="414"/>
+        <location filename="../src/playlistdownloader.cpp" line="340"/>
+        <location filename="../src/utility.cpp" line="384"/>
+        <source>Preset Options</source>
+        <translation type="Förinställda alternativ"></translation>
+    </message>
+    <message>
+        <location filename="../src/utility.cpp" line="411"/>
+        <location filename="../src/utility.h" line="482"/>
+        <location filename="../src/utility.h" line="549"/>
+        <source>Clear</source>
+        <translation type="Rensa"></translation>
+    </message>
+    <message>
+        <location filename="../src/utility.cpp" line="422"/>
+        <source>Open Download Folder</source>
+        <translation type="Öppna nerladdningsmap"></translation>
+    </message>
+    <message>
+        <location filename="../src/about.cpp" line="43"/>
+        <source>Version</source>
+        <translation type="Version"></translation>
+    </message>
+    <message>
+        <location filename="../src/about.cpp" line="44"/>
+        <source>Copyright</source>
+        <translation type="Upphovsrätt"></translation>
+    </message>
+    <message>
+        <location filename="../src/about.cpp" line="45"/>
+        <source>License</source>
+        <translation type="Licens"></translation>
+    </message>
+    <message>
+        <location filename="../src/about.cpp" line="46"/>
+        <source>Email</source>
+        <translation type="E-post"></translation>
+    </message>
+    <message>
+        <location filename="../src/about.cpp" line="52"/>
+        <source>Qt Version</source>
+        <translation type="Qt-version"></translation>
+    </message>
+    <message>
+        <location filename="../src/about.cpp" line="58"/>
+        <source>This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.</source>
+        <translation type="Detta program är fri programvara; du kan distribuera det och/eller modifiera det under villkoren i GNU General Public License som publicerats av Free Software Foundation; antingen version 2 av licensen eller (efter eget val) någon senare version."></translation>
+    </message>
+    <message>
+        <location filename="../src/about.cpp" line="59"/>
+        <source>This program is distributed in the hope that it will be useful,but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.</source>
+        <translation type="Detta program distribueras i hopp om att det ska vara användbart, men UTAN NÅGON GARANTI; utan ens den underförstådda garantin för SÄLJBARHET eller LÄMPLIGHET FÖR ETT SÄRSKILT SYFTE. Se GNU General Public License för mer information."></translation>
+    </message>
+    <message>
+        <location filename="../src/translator.cpp" line="28"/>
+        <source>Polish (Poland)</source>
+        <translation type="Polska (Poland)"></translation>
+    </message>
+    <message>
+        <location filename="../src/translator.cpp" line="29"/>
+        <source>English (US)</source>
+        <translation type="Engelska (Amerikanska"></translation>
+    </message>
+    <message>
+        <location filename="../src/translator.cpp" line="30"/>
+        <source>Spanish (Spain)</source>
+        <translation type="Spanska (Spanien)"></translation>
+    </message>
+    <message>
+        <location filename="../src/translator.cpp" line="31"/>
+        <source>Chinese (China)</source>
+        <translation type="Kinesiska (Kina)"></translation>
+    </message>
+    <message>
+        <location filename="../src/translator.cpp" line="32"/>
+        <source>Turkish (Turkey)</source>
+        <translation type="Turkiska (Turkiet)"></translation>
+    </message>
+    <message>
+        <location filename="../src/translator.cpp" line="33"/>
+        <source>Russian (Russia)</source>
+        <translation type="Ryska (Ryssland)"></translation>
+    </message>
+    <message>
+        <location filename="../src/translator.cpp" line="34"/>
+        <source>Japanese (Japan)</source>
+        <translation type="Japanska (Japan)"></translation>
+    </message>
+    <message>
+        <location filename="../src/translator.cpp" line="35"/>
+        <source>French (France)</source>
+        <translation type="Franska (Frankrike)"></translation>
+    </message>
+    <message>
+        <location filename="../src/translator.cpp" line="36"/>
+        <source>Italian (Italy)</source>
+        <translation type="Italienska (Italien)"></translation>
+    </message>
+    <message>
+        <location filename="../src/translator.cpp" line="37"/>
+        <source>Swedish (Sweden)</source>
+        <translation type="Svenska (Sverige)"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="130"/>
+        <source>Running in portable mode</source>
+        <translation type="Körs i portabelt läge"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="131"/>
+        <source>Download path: </source>
+        <translation type="Nerladdningssökväg: "></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="251"/>
+        <source>Error, executable to backend &quot;%1&quot; could not be found</source>
+        <translation type="Fel, den körbara filen &quot;%1&quot; hittades inte"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="214"/>
+        <source>Engine &quot;%1&quot; requires atleast version &quot;%2&quot; of Media Downloader</source>
+        <translation type="Motorn &quot;%1&quot; kräver minst version &quot;%2&quot; av Media downloader"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="120"/>
+        <source>To Disable These Checks, Do The Following:-</source>
+        <translation type="För att inaktivera dessa kontroller gör så här:-"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="121"/>
+        <source>1. Go To &quot;Configure&quot; Tab.</source>
+        <translation type="1. Gå till fliken &quot;Konfigurera&quot;."></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="122"/>
+        <source>2. Go To &quot;General Options&quot; Sub Tab.</source>
+        <translation type="2. Gå till underfliken &quot;Allmänna alternativ&quot;."></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="123"/>
+        <source>3. Uncheck &quot;Show Version Info When Starting&quot;.</source>
+        <translation type="3. Kryssa ur &quot;Visa versionsinformation vid start&quot;."></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="256"/>
+        <source>Error, failed to parse config file &quot;%1&quot;</source>
+        <translation type="Fel, kunde inte tolka konfigurationsfilen &quot;%1&quot;"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="492"/>
+        <source>Failed To Load A Plugin</source>
+        <translation type="Det gick inte att ladda en plugin"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="567"/>
+        <location filename="../src/engines.cpp" line="806"/>
+        <location filename="../src/utility.cpp" line="573"/>
+        <source>Failed to find executable &quot;%1&quot;</source>
+        <translation type="Det gick inte att hitta den körbara filen &quot;%1&quot;"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="791"/>
+        <source>Failed to find python3 executable for backend &quot;%1&quot;</source>
+        <translation type="Det gick inte att hitta python3 för programmet &quot;%1&quot;"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="874"/>
+        <source>Download cancelled</source>
+        <translation type="Nerladdningen avbruten"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="1020"/>
+        <source>Format Code</source>
+        <translation type="Formatkod"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="1021"/>
+        <source>Extension</source>
+        <translation type="Tillägg"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="1022"/>
+        <source>Resolution</source>
+        <translation type="Upplösning"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="1023"/>
+        <source>Note</source>
+        <translation type="Observera"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="1230"/>
+        <source>Failed to open file for writing</source>
+        <translation type="Det gick inte att öppna filen för skrivning"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="1236"/>
+        <source>Failed to open file for reading</source>
+        <translation type="Det gick inte att öppna filen för läsning"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="1381"/>
+        <location filename="../src/engines.cpp" line="1386"/>
+        <location filename="../src/engines.cpp" line="1393"/>
+        <location filename="../src/engines.cpp" line="1398"/>
+        <source>Elapsed Time:</source>
+        <translation type="Förfluten tid:"></translation>
+    </message>
+    <message>
+        <location filename="../src/networkAccess.cpp" line="59"/>
+        <location filename="../src/utility.cpp" line="930"/>
+        <source>Checking installed version of</source>
+        <translation type="Kontrollerar installerad version av"></translation>
+    </message>
+    <message>
+        <location filename="../src/networkAccess.cpp" line="64"/>
+        <location filename="../src/utility.cpp" line="907"/>
+        <location filename="../src/utility.cpp" line="956"/>
+        <source>Failed to find version information, make sure &quot;%1&quot; is installed and works properly</source>
+        <translation type="Det gick inte att hitta versionsinformation, se till att &quot;%1&quot; är installerad och fungerar som den ska"></translation>
+    </message>
+    <message>
+        <location filename="../src/networkAccess.cpp" line="67"/>
+        <location filename="../src/utility.cpp" line="952"/>
+        <source>Found version</source>
+        <translation type="Funnen version"></translation>
+    </message>
+    <message>
+        <location filename="../src/networkAccess.cpp" line="131"/>
+        <source>Failed to download, Following path can not be created: </source>
+        <translation type="Det gick inte att ladda ner, följande sökväg kan inte skapas: "></translation>
+    </message>
+    <message>
+        <location filename="../src/networkAccess.cpp" line="137"/>
+        <source>Start Downloading</source>
+        <translation type="Starta nerladdningen"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="880"/>
+        <location filename="../src/networkAccess.cpp" line="160"/>
+        <location filename="../src/networkAccess.cpp" line="269"/>
+        <source>Download Failed</source>
+        <translation type="Nerladdning misslyckad"></translation>
+    </message>
+    <message>
+        <location filename="../src/networkAccess.cpp" line="178"/>
+        <source>Failed to parse json file from github</source>
+        <translation type="Det gick inte att tolka json-filen från Github"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines/gallery-dl.cpp" line="118"/>
+        <location filename="../src/engines/gallery-dl.cpp" line="122"/>
+        <location filename="../src/networkAccess.cpp" line="232"/>
+        <location filename="../src/networkAccess.cpp" line="254"/>
+        <location filename="../src/networkAccess.cpp" line="344"/>
+        <source>Downloading</source>
+        <translation type="Laddar ner"></translation>
+    </message>
+    <message>
+        <location filename="../src/networkAccess.cpp" line="234"/>
+        <source>Destination</source>
+        <translation type="Mål"></translation>
+    </message>
+    <message>
+        <location filename="../src/networkAccess.cpp" line="280"/>
+        <source>Download complete</source>
+        <translation type="Nerladdning klar"></translation>
+    </message>
+    <message>
+        <location filename="../src/networkAccess.cpp" line="284"/>
+        <source>Extracting archive: </source>
+        <translation type="Packar upp arkiv: "></translation>
+    </message>
+    <message>
+        <location filename="../src/networkAccess.cpp" line="323"/>
+        <source>Renaming file to: </source>
+        <translation type="Döper om fil till: "></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="1299"/>
+        <source>Processing</source>
+        <translation type="Arbetar"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="878"/>
+        <source>Download completed</source>
+        <translation type="Nerladdning klar"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings.cpp" line="408"/>
+        <source>Resetting download folder to default</source>
+        <translation type="Återställer nerladdningsmappen till standard"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines.cpp" line="1344"/>
+        <source>Post Processing</source>
+        <translation type="Efterbehandling"></translation>
+    </message>
+    <message>
+        <location filename="../src/utility.h" line="515"/>
+        <location filename="../src/utility.h" line="523"/>
+        <location filename="../src/utility.h" line="528"/>
+        <source>Download</source>
+        <translation type="Ladda ner"></translation>
+    </message>
+    <message>
+        <location filename="../src/utility.h" line="520"/>
+        <source>Force Download</source>
+        <translation type="Tvinga nerladding"></translation>
+    </message>
+    <message>
+        <location filename="../src/utility.h" line="538"/>
+        <source>Show Log Window</source>
+        <translation type="Visa loggfönster"></translation>
+    </message>
+    <message>
+        <location filename="../src/utility.h" line="150"/>
+        <source>Upload Date:</source>
+        <translation type="Uppladdningsdatum:"></translation>
+    </message>
+    <message>
+        <location filename="../src/utility.h" line="154"/>
+        <source>Duration:</source>
+        <translation type="Varaktighet:"></translation>
+    </message>
+    <message>
+        <location filename="../src/utility.h" line="162"/>
+        <source>Subtitle Name</source>
+        <translation type="Undertextnamn"></translation>
+    </message>
+    <message>
+        <location filename="../src/utility.h" line="166"/>
+        <source>Download Options</source>
+        <translation type="Nerladdningsalternativ"></translation>
+    </message>
+    <message>
+        <location filename="../src/tableWidget.cpp" line="337"/>
+        <source>Completed: %1%, Not Started: %2, Succeeded: %3, Failed: %4, Cancelled: %5</source>
+        <translation type="Klara: %1%, Ej påbörjade: %2, Lyckade: %3, Misslyckade: %4, Avbrutna: %5"></translation>
+    </message>
+    <message>
+        <location filename="../src/playlistdownloader.cpp" line="1144"/>
+        <source>Media Already In Archive</source>
+        <translation type="Media finns redan i arkivet"></translation>
+    </message>
+    <message>
+        <location filename="../src/themes.h" line="71"/>
+        <source>Normal</source>
+        <translation type="Normal"></translation>
+    </message>
+    <message>
+        <location filename="../src/themes.h" line="72"/>
+        <source>Dark</source>
+        <translation type="Mörkt"></translation>
+    </message>
+    <message>
+        <location filename="../src/engines/svtplay-dl.cpp" line="41"/>
+        <source>Method</source>
+        <translation type="Metod"></translation>
+    </message>
+</context>
+<context>
+    <name>batchdownloader</name>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="1271"/>
+        <source>Set Batch File</source>
+        <translation type="Ställ in flernerladdningsfil"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="271"/>
+        <source>Open</source>
+        <translation type="Öppna"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="41"/>
+        <source>Downloading comments</source>
+        <translation type="Laddar ner kommentarer"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="995"/>
+        <source>Download</source>
+        <translation type="Ladda ner"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="1064"/>
+        <source>Save</source>
+        <translation type="Spara"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="285"/>
+        <source>Cancel</source>
+        <translation type="Avbryt"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="294"/>
+        <source>Copy Url</source>
+        <translation type="Kopiera webbadress"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="306"/>
+        <source>Remove</source>
+        <translation type="Ta bort"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="319"/>
+        <source>Show Subtitles</source>
+        <translation type="Visa undertexter"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="334"/>
+        <source>Show Comments</source>
+        <translation type="Visa kommentarer"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="347"/>
+        <source>Show Media Options</source>
+        <translation type="Visa mediaalternativ"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="1056"/>
+        <location filename="../src/batchdownloader.cpp" line="1070"/>
+        <source>Set</source>
+        <translation type="Ställ in"></translation>
+    </message>
+    <message>
+        <location filename="../src/batchdownloader.cpp" line="1435"/>
+        <location filename="../src/batchdownloader.cpp" line="1845"/>
+        <source>Downloading subtitles</source>
+        <translation type="Laddar ner undertexter"></translation>
+    </message>
+</context>
+<context>
+    <name>configure</name>
+    <message>
+        <location filename="../src/configure.cpp" line="108"/>
+        <source>Add</source>
+        <translation type="Lägg till"></translation>
+    </message>
+    <message>
+        <location filename="../src/configure.cpp" line="113"/>
+        <source>Delete</source>
+        <translation type="Radera"></translation>
+    </message>
+    <message>
+        <location filename="../src/configure.cpp" line="163"/>
+        <source>Remove</source>
+        <translation type="Ta bort"></translation>
+    </message>
+    <message>
+        <location filename="../src/configure.cpp" line="188"/>
+        <source>Select A Cookie File</source>
+        <translation type="Välj en cookie-fil"></translation>
+    </message>
+    <message>
+        <location filename="../src/configure.cpp" line="222"/>
+        <source>Select An Engine File</source>
+        <translation type="Välj en motorfil"></translation>
+    </message>
+    <message>
+        <location filename="../src/configure.cpp" line="263"/>
+        <location filename="../src/configure.cpp" line="416"/>
+        <source>Cancel</source>
+        <translation type="Avbryt"></translation>
+    </message>
+    <message>
+        <location filename="../src/configure.cpp" line="334"/>
+        <source>Set Download Folder</source>
+        <translation type="Ställ in nerladdningsmapp"></translation>
+    </message>
+    <message>
+        <location filename="../src/configure.cpp" line="576"/>
+        <source>Default</source>
+        <translation type="Standard"></translation>
+    </message>
+    <message>
+        <location filename="../src/configure.cpp" line="580"/>
+        <source>Best-audio</source>
+        <translation type="Bästa-ljud"></translation>
+    </message>
+    <message>
+        <location filename="../src/configure.cpp" line="584"/>
+        <source>Best-audiovideo</source>
+        <translation type="Bästa-ljudbild"></translation>
+    </message>
+</context>
+<context>
+    <name>library</name>
+    <message>
+        <location filename="../src/library.cpp" line="48"/>
+        <source>Delete</source>
+        <translation type="Radera"></translation>
+    </message>
+    <message>
+        <location filename="../src/library.cpp" line="76"/>
+        <source>Delete All</source>
+        <translation type="Radera allt"></translation>
+    </message>
+</context>
+<context>
+    <name>logWindow</name>
+    <message>
+        <location filename="../src/logwindow.ui" line="17"/>
+        <source>Log Window</source>
+        <translation type="Loggfönster"></translation>
+    </message>
+    <message>
+        <location filename="../src/logwindow.ui" line="32"/>
+        <source>Close</source>
+        <translation type="Stäng"></translation>
+    </message>
+    <message>
+        <location filename="../src/logwindow.ui" line="58"/>
+        <source>Clear</source>
+        <translation type="Rensa"></translation>
+    </message>
+</context>
+<context>
+    <name>playlistdownloader</name>
+    <message>
+        <location filename="../src/playlistdownloader.cpp" line="223"/>
+        <source>Open</source>
+        <translation type="Öppna"></translation>
+    </message>
+    <message>
+        <location filename="../src/playlistdownloader.cpp" line="237"/>
+        <source>Cancel</source>
+        <translation type="Avbryt"></translation>
+    </message>
+    <message>
+        <location filename="../src/playlistdownloader.cpp" line="181"/>
+        <location filename="../src/playlistdownloader.cpp" line="245"/>
+        <source>Remove</source>
+        <translation type="Ta bort"></translation>
+    </message>
+    <message>
+        <location filename="../src/playlistdownloader.cpp" line="130"/>
+        <location filename="../src/playlistdownloader.cpp" line="1294"/>
+        <source>Get List Options:</source>
+        <translation type="Hämta listalternativ"></translation>
+    </message>
+    <message>
+        <location filename="../src/playlistdownloader.cpp" line="256"/>
+        <source>Copy Url</source>
+        <translation type="Kopiera webbadress"></translation>
+    </message>
+    <message>
+        <location filename="../src/playlistdownloader.cpp" line="270"/>
+        <source>Show Comments</source>
+        <translation type="Visa kommentarer"></translation>
+    </message>
+    <message>
+        <location filename="../src/playlistdownloader.cpp" line="423"/>
+        <source>Show All Updated</source>
+        <translation type="Visa alla uppdaterade"></translation>
+    </message>
+    <message>
+        <location filename="../src/playlistdownloader.cpp" line="429"/>
+        <source>Download All Updated</source>
+        <translation type="Ladda ner alla uppdaterade"></translation>
+    </message>
+    <message>
+        <location filename="../src/playlistdownloader.cpp" line="437"/>
+        <source>Manage Subscriptions</source>
+        <translation type="Hantera prenumerationer"></translation>
+    </message>
+    <message>
+        <location filename="../src/playlistdownloader.cpp" line="1008"/>
+        <source>Number of Pages Downloaded</source>
+        <translation type="Antalet nerladdade sidor"></translation>
+    </message>
+    <message>
+        <location filename="../src/playlistdownloader.cpp" line="1015"/>
+        <source>Downloading video info</source>
+        <translation type="Laddar ner videoinformation"></translation>
+    </message>
+    <message>
+        <location filename="../src/playlistdownloader.cpp" line="549"/>
+        <source>This May Take A Very Long Time</source>
+        <translation type="Detta kan ta väldigt lång tid"></translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
I also found a typo in the source string `Maximum Cuncurrent Downloads`, it should be `Concurrent`

Kind of a typo `Path To Cookie FIle` because the letter `i` is in upper case.

Also a kind of typo `Engine &quot;%1&quot; requires atleast version &quot;%2&quot; of Media Downloader`, `at least` should be two words.

Systray or Tray is now called `Notification area`, so maybe you should change `Show Tray Icon` to `Show icon in Notification area`?

If i understand this correct you need to add a new line to every language file when a new language will be added? Maybe you should think of making that a bit easier?

I was thinking of sorting the languages in alphabetical order, but that require changes in all the language file, so i won't do it (maybe you can write some code that will sort them in the dropdown menu?).