### PR TITLE
add playlist_autonumber

### DIFF
--- a/src/engines/yt-dlp.cpp
+++ b/src/engines/yt-dlp.cpp
@@ -714,6 +714,7 @@ void yt_dlp::updateDownLoadCmdOptions( const engines::engine::functions::updateO
 
 				e.replace( "%(autonumber)s",s.uiIndex.toString( s.ourOptions ) ) ;
 				e.replace( "%(playlist_index)s",s.uiIndex.toString() ) ;
+				e.replace( "%(playlist_autonumber)s",s.uiIndex.toString( s.ourOptions ) ) ;
 				e.replace( "%(playlist_id)s",s.playlist_id ) ;
 				e.replace( "%(playlist_title)s",s.playlist_title ) ;
 				e.replace( "%(playlist)s",s.playlist ) ;


### PR DESCRIPTION
`playlist_autonumber` (numeric): Position of the video in the playlist download queue padded with leading zeros according to the total length of the playlist, starting at `--autonumber-start`