### PR TITLE
Make "Windows Only" proxy option disappear on non-Windows

### DIFF
--- a/src/configure.cpp
+++ b/src/configure.cpp
@@ -561,7 +561,17 @@ configure::configure( const Context& ctx ) :
 	auto proxy      = m_ctx.Settings().getProxySettings() ;
 	auto proxy_type = proxy.types() ;
 
-	m_ui.rbUseSystemProxy->setEnabled( utility::platformIsWindows() ) ;
+    if( !utility::platformIsWindows() )
+    {
+        auto systemProxyHeight = m_ui.rbUseSystemProxy->height() ;
+        m_ui.rbUseSystemProxy->hide() ;
+
+        auto& fromEnv = m_ui.rbGetFromEnv ;
+        fromEnv->move( fromEnv->x(), fromEnv->y() - systemProxyHeight ) ;
+
+        auto& manual = m_ui.rbUseManualProxy ;
+        manual->move( manual->x(), manual->y() - systemProxyHeight ) ;
+    }
 
 	if( proxy_type.manual() ){
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -2240,7 +2240,7 @@
          </rect>
         </property>
         <property name="text">
-         <string>Use System Proxy Configuration(Windows Only)</string>
+         <string>Use System Proxy Configuration</string>
         </property>
        </widget>
        <widget class="QRadioButton" name="rbUseManualProxy">


### PR DESCRIPTION
Instead of only disabling the radio option "Use System Proxy(Windows Only)" if not on Windows, hides it and moves the other options up to fill its place at runtime. It removes the unnecessary button on non-Windows and removes the clutter of saying it's Windows only when you're actually on Windows. Additionally, disabling a radio button doesn't show any difference on my theming so you couldn't even tell it was disabled unless you clicked on it.

Old:
![Before Commit](https://github.com/mhogomchungu/media-downloader/assets/130006737/a2d29cbe-2f67-4063-9430-e2816056bda4)

New:
![After Commit](https://github.com/mhogomchungu/media-downloader/assets/130006737/b7df5895-01a8-4ca3-8ebb-40dcae6bb95d)
