### PR TITLE
Update LICENSE.txt (no forced CR/LF)

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -3,16 +3,11 @@ copyright (c) 2021-2024
 name : Francis Banyikwa
 email: mhogomchungu@gmail.com
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 2 of the License, or
-(at your option) any later version.
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License along with this program.  
+If not, see <http://www.gnu.org/licenses/>.
 


### PR DESCRIPTION
@mhogomchungu 

I didn't change text of license.
I removed forced CR/LF (max 80 chars for lines) because in the instalelr has no sense to have force CR/LF at 80 chars.

![image](https://github.com/mhogomchungu/media-downloader/assets/1262554/f0c330c5-45e9-428c-8719-c8b110845f6b)

.