### PR TITLE
Add scoop commands to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ A portable version is a self-contained version that keeps everything in the appl
 
 Portable version for Microsoft Windows is [here](https://github.com/mhogomchungu/media-downloader/releases/download/4.7.0/MediaDownloader-4.7.0.zip).
 
+You can also install the portable version for Windows using scoop with the following commands:
+
+Add the extras bucket:
+```powershell
+scoop bucket add extras
+```
+Install Media Downloader:
+```powershell
+scoop install media-downloader
+```
+
 Git versions for windows and macos can be downloaded from [here](https://github.com/mhogomchungu/media-downloader-git/releases).
 
 #### Aur package for Arch Linux


### PR DESCRIPTION
Hi @mhogomchungu

Media Download can now be installed using Scoop on Windows: https://github.com/ScoopInstaller/Extras/pull/13436

In this pull request, I've added commands for installing media-downloader using Scoop in the section about installing the Windows portable version. Please let me know what you think about the changes in the README file. I will change it however you see fit, or feel free to change it yourself if you would like.

I think you can now close this issue: #266.