### PR TITLE
Add Fedora build script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ chmod +x build_linux.sh
 ./build_linux.sh
 ```
 
+
+### Fedora
+
+Fedora users can use the following script to build from source:
+
+```bash
+./build_fedora.sh
+
 # Screenshots
 
 

--- a/build_fedora.sh
+++ b/build_fedora.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+# Update system
+sudo dnf -y update
+
+# Install essential build tools individually (instead of group)
+sudo dnf -y install gcc gcc-c++ make automake autoconf libtool \
+    cmake git
+
+# Install Qt5 development packages
+sudo dnf -y install qt5-qtbase-devel qt5-qtdeclarative-devel \
+    qt5-qtquickcontrols2-devel qt5-qtwebsockets-devel \
+    qt5-qtwebchannel-devel qt5-qttools-devel
+
+# Build media-downloader
+cd ~/media-downloader
+rm -rf build
+mkdir build
+cd build
+
+cmake ..
+make -j"$(nproc)"
+
+chmod +x media-downloader
+


### PR DESCRIPTION
Hi,

I added a new script `build_fedora.sh` for building on Fedora (tested on Fedora 41 with dnf5). 
This avoids the `groupinstall Development Tools` issue since it’s no longer available in dnf5.  

I also updated the README to include Fedora-specific build instructions.  

Thanks for maintaining this project!  
— Faris Ghazi