### PR TITLE
Fix: close code block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ chmod +x build_linux.sh
 
 Fedora users can use the following script to build from source:
 
-```bash
+```console
 ./build_fedora.sh
+```
 
 # Screenshots
 


### PR DESCRIPTION
Fixes the README by closing a code block added in 5b8bda4. Now the screenshots and the rest of the README renders as expected. 